### PR TITLE
test: increase timeout

### DIFF
--- a/test/Blazor/Aguacongas.DynamicConfiguration.Razor.Test/SettingsTest.cs
+++ b/test/Blazor/Aguacongas.DynamicConfiguration.Razor.Test/SettingsTest.cs
@@ -133,7 +133,7 @@ namespace Aguacongas.DynamicConfiguration.Razor.Test
                 .Add(p => p.RootPath, "/")
                 .Add(p => p.Path, "Child:Dictionary:test"));
 
-            cut.WaitForState(() => !cut.Markup.Contains("Loading..."), TimeSpan.FromSeconds(2));
+            cut.WaitForState(() => !cut.Markup.Contains("Loading..."), TimeSpan.FromSeconds(15));
 
             Assert.Contains("<span>Dictionary</span>",
                 cut.Markup);


### PR DESCRIPTION
test: increase timeout

Increase timeout for component loading in tests

Updated the timeout duration for the `WaitForState` method from 2 seconds to 15 seconds to provide additional time for the component to finish loading before assertions are made.